### PR TITLE
Check for document before initializing the Worker

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,14 +1,22 @@
 import { load } from 'web-audio-beat-detector-broker';
 import { worker } from './worker/worker';
 
-const blob: Blob = new Blob([worker], { type: 'application/javascript; charset=utf-8' });
+let analyze, guess
 
-const url: string = URL.createObjectURL(blob);
+if (typeof document !== 'undefined') {
 
-const webAudioBeatDetector = load(url);
+  const blob: Blob = new Blob([worker], { type: 'application/javascript; charset=utf-8' });
 
-export const analyze = webAudioBeatDetector.analyze;
+  const url: string = URL.createObjectURL(blob);
 
-export const guess = webAudioBeatDetector.guess;
+  const webAudioBeatDetector = load(url);
 
-URL.revokeObjectURL(url);
+  analyze = webAudioBeatDetector.analyze;
+
+  guess = webAudioBeatDetector.guess;
+
+  URL.revokeObjectURL(url);
+
+}
+
+export { analyze, guess }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,8 @@
 import { load } from 'web-audio-beat-detector-broker';
 import { worker } from './worker/worker';
 
-let analyze, guess
+let analyze: ReturnType<typeof load>['analyze'];
+let guess: ReturnType<typeof load>['guess'];
 
 if (typeof document !== 'undefined') {
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,11 +10,7 @@ if (typeof document !== 'undefined') {
 
   const url: string = URL.createObjectURL(blob);
 
-  const webAudioBeatDetector = load(url);
-
-  analyze = webAudioBeatDetector.analyze;
-
-  guess = webAudioBeatDetector.guess;
+  ;({analyze, guess} = load(url))
 
   URL.revokeObjectURL(url);
 


### PR DESCRIPTION
I believe this is related to https://github.com/chrisguttandin/web-audio-beat-detector/issues/285, as it addresses a similar error "TypeError: The "obj" argument must be an instance of Blob. Received an instance of Blob" when trying to import the module using Remix (an SSR-based framework which identifies the workaround for this issue here: https://remix.run/docs/en/v1/guides/constraints#document-guard)

This fixes the issue for me locally, although I can't be sure how this might impact other configurations.